### PR TITLE
Add Vietnamese login and Bao Moi news page

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'placekitten.com',
+        pathname: '/**',
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/src/app/bao-moi/page.tsx
+++ b/src/app/bao-moi/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import { Layout, Row, Col } from 'antd';
+
+const { Header, Content } = Layout;
+
+interface Article {
+  title: string;
+  source: string;
+  time: string;
+  image: string;
+}
+
+const articles: Article[] = [
+  {
+    title: 'Thủ tướng: Chuyển đổi số là động lực phát triển',
+    source: 'VnExpress',
+    time: '1 giờ trước',
+    image: 'https://placekitten.com/200/120',
+  },
+  {
+    title: 'Giá vàng tăng mạnh trong phiên sáng',
+    source: 'Tuổi Trẻ',
+    time: '2 giờ trước',
+    image: 'https://placekitten.com/201/120',
+  },
+  {
+    title: 'U23 Việt Nam thắng đậm trong trận giao hữu',
+    source: 'Thanh Niên',
+    time: '3 giờ trước',
+    image: 'https://placekitten.com/202/120',
+  },
+  {
+    title: 'Công nghệ AI ngày càng phổ biến trong giáo dục',
+    source: 'VNReview',
+    time: '4 giờ trước',
+    image: 'https://placekitten.com/203/120',
+  },
+  {
+    title: 'Khởi nghiệp xanh thu hút nhà đầu tư',
+    source: 'Dân Trí',
+    time: '5 giờ trước',
+    image: 'https://placekitten.com/204/120',
+  },
+  {
+    title: 'Ẩm thực đường phố Việt Nam gây ấn tượng',
+    source: 'Zing',
+    time: '6 giờ trước',
+    image: 'https://placekitten.com/205/120',
+  },
+];
+
+const highlights: Article[] = [
+  {
+    title: 'Kinh tế Việt Nam phục hồi sau đại dịch',
+    source: 'VnEconomy',
+    time: '1 giờ trước',
+    image: 'https://placekitten.com/100/60',
+  },
+  {
+    title: 'Lễ hội pháo hoa quốc tế sắp diễn ra',
+    source: 'Tuổi Trẻ',
+    time: '2 giờ trước',
+    image: 'https://placekitten.com/101/60',
+  },
+  {
+    title: 'Xe điện đang trở thành xu hướng mới',
+    source: 'AutoPro',
+    time: '3 giờ trước',
+    image: 'https://placekitten.com/102/60',
+  },
+  {
+    title: 'Du lịch hè: Những điểm đến hấp dẫn',
+    source: 'TravelMag',
+    time: '4 giờ trước',
+    image: 'https://placekitten.com/103/60',
+  },
+  {
+    title: 'Các trường đại học mở ngành học mới',
+    source: 'VTV',
+    time: '5 giờ trước',
+    image: 'https://placekitten.com/104/60',
+  },
+];
+
+const BaoMoi: React.FC = () => (
+  <Layout style={{ minHeight: '100vh', background: '#f5f5f5' }}>
+    <Header
+      style={{
+        background: '#1e6bb8',
+        color: '#fff',
+        display: 'flex',
+        alignItems: 'center',
+        padding: '0 24px',
+      }}
+    >
+      <h1 style={{ color: '#fff', margin: 0, fontSize: 24 }}>BÁO MỚI</h1>
+      <nav style={{ marginLeft: 24, display: 'flex', gap: 16 }}>
+        <a style={{ color: '#fff' }} href="#">Tin mới</a>
+        <a style={{ color: '#fff' }} href="#">Thế giới</a>
+        <a style={{ color: '#fff' }} href="#">Kinh doanh</a>
+        <a style={{ color: '#fff' }} href="#">Giải trí</a>
+      </nav>
+    </Header>
+    <Content style={{ padding: '24px', maxWidth: 1200, margin: '0 auto' }}>
+      <Row gutter={24}>
+        <Col xs={24} md={16}>
+          {articles.map((article) => (
+            <div
+              key={article.title}
+              style={{
+                display: 'flex',
+                marginBottom: 24,
+                background: '#fff',
+                padding: 12,
+                borderRadius: 4,
+              }}
+            >
+              <Image
+                alt={article.title}
+                src={article.image}
+                width={200}
+                height={120}
+                style={{ objectFit: 'cover', borderRadius: 4 }}
+              />
+              <div style={{ marginLeft: 16 }}>
+                <h3 style={{ margin: 0, color: '#1e6bb8' }}>{article.title}</h3>
+                <p style={{ margin: '4px 0', color: '#666' }}>
+                  {article.source} - {article.time}
+                </p>
+              </div>
+            </div>
+          ))}
+        </Col>
+        <Col xs={24} md={8}>
+          <h2 style={{ marginTop: 0 }}>Tin nổi bật</h2>
+          {highlights.map((article) => (
+            <div key={article.title} style={{ display: 'flex', marginBottom: 16 }}>
+              <Image
+                alt={article.title}
+                src={article.image}
+                width={80}
+                height={50}
+                style={{ objectFit: 'cover', borderRadius: 4 }}
+              />
+              <div style={{ marginLeft: 8 }}>
+                <p style={{ margin: 0 }}>{article.title}</p>
+                <p style={{ margin: '4px 0', color: '#666', fontSize: 12 }}>
+                  {article.source} - {article.time}
+                </p>
+              </div>
+            </div>
+          ))}
+        </Col>
+      </Row>
+    </Content>
+  </Layout>
+);
+
+export default BaoMoi;
+

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -26,6 +26,7 @@ interface ColumnType {
   title: string;
   dataIndex?: string;
   key: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   render?: (text: any, record?: DataType) => React.ReactNode;
 }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -10,13 +10,13 @@ const Login = () => {
 
   const onFinish = (values: unknown) => {
     console.log('Success:', values);
-    message.success('Login successful!');
+    message.success('Đăng nhập thành công!');
     router.push('/home');
   };
 
   const onFinishFailed = (errorInfo: unknown) => {
     console.log('Failed:', errorInfo);
-    message.error('Login failed. Please try again.');
+    message.error('Đăng nhập thất bại. Vui lòng thử lại.');
   };
 
   return (
@@ -24,10 +24,10 @@ const Login = () => {
       <Col span={12} style={{ background: '#141414', padding: '50px' }}>
         <S.LoginFormWrapper>
           <S.QuoteTitle level={2} style={{ color: '#fff' }}>
-            Hello, <S.HighlightText>Digital Fortress</S.HighlightText>
+            Xin chào, <S.HighlightText>Digital Fortress</S.HighlightText>
           </S.QuoteTitle>
           <S.LoginSubtitle>
-            Log in to platform to start creating magic.
+            Đăng nhập vào nền tảng để bắt đầu tạo điều kỳ diệu.
           </S.LoginSubtitle>
           <Form
             layout="vertical"
@@ -36,7 +36,7 @@ const Login = () => {
           >
             <Form.Item
               name="email"
-              rules={[{ required: true, message: 'Please input your email!' }]}
+              rules={[{ required: true, message: 'Vui lòng nhập email!' }]}
             >
               <S.LoginInput
                 prefix={<MailOutlined />}
@@ -46,41 +46,32 @@ const Login = () => {
             </Form.Item>
             <Form.Item
               name="password"
-              rules={[{ required: true, message: 'Please input your password!' }]}
+              rules={[{ required: true, message: 'Vui lòng nhập mật khẩu!' }]}
             >
               <S.PasswordInput 
                 prefix={<LockOutlined />}
-                placeholder="Password"
+                placeholder="Mật khẩu"
                 size="large"
                 type="password"
               />
             </Form.Item>
             <S.LoginFooter>
-              <S.LoginCheckbox>Remember me</S.LoginCheckbox>
-              <S.ForgotPasswordLink>Forgot Password?</S.ForgotPasswordLink>
+              <S.LoginCheckbox>Ghi nhớ tôi</S.LoginCheckbox>
+              <S.ForgotPasswordLink>Quên mật khẩu?</S.ForgotPasswordLink>
             </S.LoginFooter>
             <Form.Item>
               <S.LoginButton type="primary" htmlType="submit" block size="large">
-                Log in
+                Đăng nhập
               </S.LoginButton>
             </Form.Item>
             <S.SignupText>
-              Don’t have an account? <S.SignupLink>Sign Up</S.SignupLink>
+              Chưa có tài khoản? <S.SignupLink>Đăng ký</S.SignupLink>
             </S.SignupText>
           </Form>
         </S.LoginFormWrapper>
       </Col>
 
       <S.LoginImageContainer span={12}>
-        {/* <S.LoginQuote>
-          <S.QuoteTitle level={3}>
-            Digital Fortress has been a game-changer for our content creation process.
-          </S.QuoteTitle>
-          <S.QuoteText>
-            The AI-powered tools are incredibly user-friendly and have saved us countless hours of work.
-          </S.QuoteText>
-          <S.QuoteText>- Lily Alisson, CMO at Digital Fortress</S.QuoteText>
-        </S.LoginQuote> */}
       </S.LoginImageContainer>
     </Row>
   );


### PR DESCRIPTION
## Summary
- localize login page messaging and labels in Vietnamese
- remove commented login quote markup
- silence ColumnType any-type lint error
- add Bao Moi news page with sample articles styled like a news site
- configure Next.js to load remote images from placekitten.com
- revamp Bao Moi page with navigation, main feed, and highlights sidebar to resemble baomoi.com

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aa582bcd08333b473b4c901fb83c9